### PR TITLE
feat(ssl): Purge ssl from containers. Reverse proxy on host with certficate

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ sudo docker exec -it nugu-server /bin/bash -c "echo SYSOP && passwd sysop && ech
 sudo docker exec nugu-server /bin/bash -c "\
   a2ensite home && \
   a2dissite 000-default && \
-  service apache2 reload"
+  service apache2 restart"
 ```
 
 ## Setup
@@ -74,3 +74,5 @@ certbot --nginx -d sparcs.org nugu.sparcs.org
 # 3. Disagree sharing email
 # 4. 2: Redirect
 ```
+
+* Check whether sparcs.org and nugu.sparcs.org are working fine or not.

--- a/README.md
+++ b/README.md
@@ -10,26 +10,11 @@ sudo docker exec -it nugu-server /bin/bash -c "echo SYSOP && passwd sysop && ech
 * You should issue and install the certificate by executing the follwing command at your host:
 ```shell
 sudo docker exec nugu-server /bin/bash -c "\
-  service apache2 stop && \
-  /certbot-auto certonly -n --apache -m wheel@sparcs.org --agree-tos -d sparcs.org -d www.sparcs.org -d nugu.sparcs.org && \
-  a2dissite 000-default && \
   a2ensite home && \
-  service apache2 restart && \
+  a2dissite 000-default && \
   service apache2 reload"
 ```
-* After finishing the jobs, you should contact the KAIST IC team and change the DNS record of `sparcs.kaist.ac.kr`.
-* Issue certificates for `sparcs.kaist.ac.kr`.
-```shell
-sudo docker exec nugu-server /bin/bash -c "\
-  service apache2 stop && \
-  a2dissite home && \
-  a2ensite 000-default && \
-  /certbot-auto certonly -n --apache -m wheel@sparcs.org --agree-tos -d sparcs.kaist.ac.kr && \
-  a2dissite 000-default && \
-  a2ensite home && \
-  service apache2 restart && \
-  service apache2 reload"
-```
+
 ## Setup
 ```shell
 sudo apt-get update
@@ -65,4 +50,27 @@ sudo /bin/bash -c \
   * `home.conf`
 ```shell
 sudo docker-compose up -d
+```
+* After containers are up, you should proxy each domain's request to corresponding container
+```shell
+sudo apt-get -y install nginx
+cp /path/to/sparcs.org /etc/nginx/sites-available/sparcs.org # sparcs.org can be found in repository root
+cp /path/to/nugu.sparcs.org /etc/nginx/sites-available/sparcs.org
+sudo ln -s /etc/nginx/sites-available/sparcs.org /etc/ngins/sites-enabled/sparcs.org
+sudo ln -s /etc/nginx/sites-available/nugu.sparcs.org /etc/ngins/sites-enabled/nugu.sparcs.org
+sudo systemctl start nginx
+```
+
+* After nginx is up, you should generate ssl certificate to each domains with certbot.
+```shell
+apt-get install -y software-properties-common python-software-properties
+add-apt-repository ppa:certbot/certbot
+apt-get update
+apt-get install -y python-certbot-apache
+certbot --nginx -d sparcs.org nugu.sparcs.org
+# On prompt, enter
+# 1. wheel@sparcs.org
+# 2. Agree to terms of service
+# 3. Disagree sharing email
+# 4. 2: Redirect
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     build: ./home-server
     tty: true
     ports:
+      - "10000:15693"
       - "8022:22"
     volumes:
       - ./log-home:/root/.forever
@@ -34,12 +35,7 @@ services:
     build: ./nugu-server
     tty: true
     ports:
-      - "80:80"
-      - "443:443"
+      - "10002:80"
       - "8023:22"
     volumes:
       - ./log-nugu:/var/log/apache2
-    links:
-      - home-server:home-server
-    depends_on:
-      - home-server

--- a/nugu-server/Dockerfile
+++ b/nugu-server/Dockerfile
@@ -40,4 +40,4 @@ COPY ./settings_local.py /nugu-api/nugu/settings_local.py
 WORKDIR /nugu-api
 RUN pip install -r requirements.txt
 
-CMD /bin/bash -c "service ssh start && service cron start && /bin/bash"
+CMD /bin/bash -c "service ssh start && /bin/bash"

--- a/nugu-server/Dockerfile
+++ b/nugu-server/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get install -y \
     tmux \
     locales \
     wget \
-    cron \
 	git \
 	mysql-client \
 	libmysqlclient-dev \
@@ -32,25 +31,13 @@ RUN echo "export LANG=ko_KR.UTF-8" >> /etc/environment
 RUN echo "export LANGUAGE=ko_KR.UTF-8" >> /etc/environment
 RUN echo "export LC_ALL=ko_KR.UTF-8" >> /etc/environment
 
-# Certbot installation
-RUN wget https://dl.eff.org/certbot-auto
-RUN chmod u+x certbot-auto
-
 # Apache configuration
 COPY ./home.conf /etc/apache2/sites-available/home.conf
-RUN a2enmod ssl
-RUN a2enmod proxy_http
 
 # Repository cloning and pip installation
 RUN git clone https://github.com/sparcs-kaist/nugu-api.git
 COPY ./settings_local.py /nugu-api/nugu/settings_local.py
 WORKDIR /nugu-api
 RUN pip install -r requirements.txt
-
-# Crontab installation
-RUN echo "# m h dom mon dow command" > mycron
-RUN echo "  0 4 *   *   1   /certbot-auto --renew" >> mycron
-RUN crontab mycron
-RUN rm mycron
 
 CMD /bin/bash -c "service ssh start && service cron start && /bin/bash"

--- a/nugu-server/home.conf
+++ b/nugu-server/home.conf
@@ -1,41 +1,6 @@
 WSGIPythonPath /nugu-api:/usr/local/lib/python3.4/site-packages
 
 <VirtualHost *:80>
-    ServerName sparcs.org
-    ServerAlias www.sparcs.org sparcs.kaist.ac.kr
-    Redirect permanent / https://sparcs.org/
-</VirtualHost>
-
-<VirtualHost *:80>
-    ServerName nugu.sparcs.org
-    Redirect permanent / https://nugu.sparcs.org/
-</VirtualHost>
-
-<VirtualHost *:443>
-    ServerName www.sparcs.org
-    ServerAlias sparcs.kaist.ac.kr
-    Redirect permanent / https://sparcs.org/
-
-    SSLEngine on
-    SSLCertificateFile /etc/letsencrypt/live/sparcs.org/fullchain.pem
-    SSLCertificateKeyFile /etc/letsencrypt/live/sparcs.org/privkey.pem
-</VirtualHost>
-
-<VirtualHost *:443>
-    ServerAdmin wheel@sparcs.org
-    ServerName sparcs.org
-
-    ProxyPreserveHost On
-    ProxyRequests Off
-    ProxyPass / http://home-server:15693/
-    ProxyPassReverse / http://home-server:15693/
-
-    SSLEngine on
-    SSLCertificateFile /etc/letsencrypt/live/sparcs.org/fullchain.pem
-    SSLCertificateKeyFile /etc/letsencrypt/live/sparcs.org/privkey.pem
-</VirtualHost>
-
-<VirtualHost *:443>
     ServerAdmin wheel@sparcs.org
     ServerName nugu.sparcs.org
 
@@ -47,8 +12,4 @@ WSGIPythonPath /nugu-api:/usr/local/lib/python3.4/site-packages
         Require all granted
     </Files>
     </Directory>
-
-    SSLEngine on
-    SSLCertificateFile /etc/letsencrypt/live/sparcs.org/fullchain.pem
-    SSLCertificateKeyFile /etc/letsencrypt/live/sparcs.org/privkey.pem
 </VirtualHost>

--- a/nugu.sparcs.org
+++ b/nugu.sparcs.org
@@ -1,0 +1,13 @@
+server {
+  listen 80;
+
+	server_name nugu.sparcs.org;
+
+	location / {
+    proxy_pass http://localhost:10002;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+	}
+}

--- a/sparcs.org
+++ b/sparcs.org
@@ -1,0 +1,13 @@
+server {
+  listen 80;
+
+	server_name sparcs.org;
+
+	location / {
+    proxy_pass http://localhost:10000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+	}
+}


### PR DESCRIPTION
컨테이너 안의 ssl 설정을 모두 제거하였습니다.
domain 설정은 host에서 nginx reverse proxy로 처리하도록 변경하였고
SSL 인증서도 host의 nginx에서 처리하도록 하였습니다.

nugu-server container에 요청이 정상적으로 도달하는건 확인했지만 장고 서버가 정상적으로 작동하지 않는 이슈가 있습니다.